### PR TITLE
Fixed Labels on add/remove course

### DIFF
--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -228,15 +228,15 @@ Currently, only attendance information is served
 							<div class="collapsible-body">
 								<div class="row">
 									<div class="input-field col s12 m6 l3">
-										<input placeholder="CS/MAT165" id="addCourseName">
+										<input placeholder="CS/MAT165" class="validate" type="text" id="addCourseName">
 										<label for="addCourseName">Course Name</label>
 									</div>
 									<div class="input-field col s12 m6 l3">
-										<input placeholder="Discrete Mathmatics" id="addCourseTitle">
+										<input placeholder="Discrete Mathmatics" class="validate" type="text" id="addCourseTitle">
 										<label for="addCouseTitle">Course Title</label>
 									</div>
 									<div class="input-field col s12 m6 l3">
-										<input placeholder="4" id="addCourseCredits">
+										<input placeholder="4" class="validate" type="number" id="addCourseCredits">
 										<label for="addCouseCredits">Number of Credits</label>
 									</div>
 
@@ -254,11 +254,11 @@ Currently, only attendance information is served
 							<div class="collapsible-body">
 								<div class="row">
 									<div class="input-field col s12 m6 l3">
-										<input id="removeCourseName">
+										<input type="text" class="validate" id="removeCourseName">
 										<label for="removeCourseName">Course Name</label>
 									</div>
 									<div class="input-field col s12 m6 l3">
-										<input id="removeCourseTitle">
+										<input class="validate" type="text" id="removeCourseTitle">
 										<label for="removeCouseTitle">Course Title</label>
 									</div>
 


### PR DESCRIPTION
Fixed the issue where the labels for the parameters of add and remove a course will not move to be above the input field or will not stay above the input field when placeholder text is present.  
Also added the type parameter to the input tags to specify the type of input expected.

fixes #73