### PR TITLE
Fix Search for Course Spelling Issue and Retitled Search for Courses Button

### DIFF
--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -286,7 +286,7 @@ Currently, only attendance information is served
 										<!--Add in searching options later-->
 									</div>
 									<a id="btnPerformSearch" class="waves-effect waves-light btn">
-										Search for courses
+										Perform Search
 									</a>
 
 								</div>

--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -278,8 +278,8 @@ Currently, only attendance information is served
 						<ul id="searchCourseBox" class="collapsible" data-collapsible="expandable">
 							<li>
 								<div class="collapsible-header">
-									<i id="dbInfoArrow" class="material-icons">keyboard_arrow_down</i>S
-									Sesrch for courses
+									<i id="dbInfoArrow" class="material-icons">keyboard_arrow_down</i>
+									Search for Courses
 								</div>
 								<div class="collapsible-body">
 									<div class="row">


### PR DESCRIPTION
Fixed the typo in `index.html` where there was an issue where "Search For Courses" was incorrectly spelled. This issue has been fixed now and **Search For Courses** is now spelled without typos.  
<br>
Also in this PR, the Search for Courses button now has a new title called **Perform Search**. This was done to make it so that the button takes up less screen real estate and make it so that the button is easier to understand what is happening when the button is pressed.