### PR TITLE
Fix Issue Template Labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/client-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/client-bug-report.md
@@ -2,7 +2,7 @@
 name: Client Bug Report
 about: This template should be used when an issue arises on a client machine. Please
   fill in all of the information below.
-title: "[Client Bug]"
+title: "[Client Bug] title_goes_here"
 labels: Type - Bug, Location - Client
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/client-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/client-bug-report.md
@@ -3,7 +3,7 @@ name: Client Bug Report
 about: This template should be used when an issue arises on a client machine. Please
   fill in all of the information below.
 title: "[Client Bug]"
-labels: Bug, Client
+labels: Type - Bug, Location - Client
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,14 +3,14 @@ name: Feature Request
 about: To request a new Feature be added to our product, Please fill in all of the
   fields.
 title: "[Feature Request] title_of_feature_request"
-labels: Enhancement
+labels: Type - Enhancement
 assignees: ''
 
 ---
 
 **Please Describe the Feature**
 [text goes here]
-  
+
 **Does the Feature Require a Database Change?**  
 Please check one of the boxes:  
 - [ ] Yes
@@ -18,26 +18,26 @@ Please check one of the boxes:
 
 **If Yes, Please describe the change that would be needed in detail. (Include any screenshots or supporting material if needed)**  
 [text goes here]
-  
+
 
 **Does the Feature Require a Web server Change?**  
 Please check one of the boxes:  
 - [ ] Yes
 - [ ] No
-  
+
 **If yes, please describe the Web server change needed**  
 [text goes here]
-  
+
 
 
 **Does the Feature Require a User Interface Change?**  
 Please check one of the boxes:  
 - [ ] Yes
 - [ ] No
-  
+
 **If yes, Please describe the changes that are needed and include any screenshots or supporting documents**  
 [text goes here]
-  
+
 ***
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/idea-request.md
+++ b/.github/ISSUE_TEMPLATE/idea-request.md
@@ -3,7 +3,7 @@ name: Idea Request
 about: Suggest an Idea that you would like  to see be added to our Product. Please
   fill in all of the information below.
 title: "[IDEA] idea_title_goes_here"
-labels: ''
+labels: 'Idea/Non_Issue'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/server-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/server-bug-report.md
@@ -3,7 +3,7 @@ name: Server Bug Report
 about: This template should be used when there is an issue with either the Database
   or the Webserver. Please fill in all of the information below.
 title: "[Server Bug]"
-labels: Bug, Server
+labels: Type - Bug, Location - Server
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/server-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/server-bug-report.md
@@ -1,8 +1,8 @@
 ---
 name: Server Bug Report
 about: This template should be used when there is an issue with either the Database
-  or the Webserver. Please fill in all of the information below.
-title: "[Server Bug]"
+  or the Web Server. Please fill in all of the information below.
+title: "[Server Bug] title_goes_here"
 labels: Type - Bug, Location - Server
 assignees: ''
 


### PR DESCRIPTION
Updated the labels on all Issue Templates so that they all should show up again when creating new issues based off of the templates.  
Fixed a spelling error and added in `title_goes_here` on *Client Bug Report* and *Server Bug Report* to make it more understanding on where the title should go in the template.  
***
This branch **is intended** to be merged directly into *dev* so that the templates will start working as soon as possible and since there is no functionality to the actual product being added in this PR.