### PR TITLE
Apply Patch 1 to Gradebook 0.5.9

### DIFF
--- a/src/db/addTermMgmt.sql
+++ b/src/db/addTermMgmt.sql
@@ -5,13 +5,13 @@
 --Function to get all terms that a course if offered
 -- returns the term's ID, season (i.e. spring), year (i.e 2019)
 
-CREATE OR REPLACE FUNCTION getTerms()
+CREATE OR REPLACE FUNCTION gradebook.getTerms()
 RETURNS Table(outID INT, outSeason VARCHAR, outYear NUMERIC(4,0)) AS
 $$
 BEGIN
 RETURN QUERY
     SELECT T.ID, S.Name, T.Year
-    FROM Gradebook.Term T INNER JOIN Gradebook.Season S 
+    FROM Gradebook.Term T INNER JOIN Gradebook.Season S
     ON (T.Season = S."Order");
 END
 $$

--- a/src/webapp/client/js/index.js
+++ b/src/webapp/client/js/index.js
@@ -736,8 +736,9 @@ function getTerms(connInfo) {
 		success: function(result) {
 			var terms = '';
 			for (var i = 0; i < result.terms.length; i++) {
-				terms += '<option value="' + result.terms[i] + '">' +
-				result.terms[i] + '</option>';
+				console.log("terms: " + result.terms[i].terms);
+				terms += '<option value="' + result.terms[i].terms + '">' +
+				result.terms[i].terms + '</option>';
 			}
 			console.log(result);
 			setTerms(terms);

--- a/src/webapp/gradebookServer.js
+++ b/src/webapp/gradebookServer.js
@@ -619,7 +619,7 @@ app.get('/getTerms', function(request, response){
          for (row in result.rows) {
                terms.push(
                   {
-                     "terms": result.rows[row].outSeason
+                     "terms": result.rows[row].outseason
                   }
                );
          }


### PR DESCRIPTION
Added schema qualification to Term Management to prevent an error where terms do not populate.  
***
Also fixed an issue where capitalization in Gradebook Server was causing issues.